### PR TITLE
feat(package): add release validation and tagging foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: Package CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+      - run: npm test

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,210 @@
+name: Tag release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: release-main
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Validate release candidate
+    runs-on: ubuntu-latest
+    outputs:
+      should_tag: ${{ steps.release.outputs.should_tag }}
+      version: ${{ steps.release.outputs.version }}
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 22
+      - run: npm test
+      - name: Verify merged pull request provenance
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          pulls_json="$(gh api --method GET --paginate --slurp \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/pulls?per_page=100")" || {
+            echo "Could not verify pull request provenance for $GITHUB_SHA." >&2
+            exit 1
+          }
+          printf '%s' "$pulls_json" | GITHUB_SHA="$GITHUB_SHA" node -e '
+            let input = "";
+            process.stdin.on("data", (chunk) => input += chunk).on("end", () => {
+              const pages = JSON.parse(input);
+              if (!Array.isArray(pages) || pages.some((page) => !Array.isArray(page))) {
+                throw new Error("pull request association API response is not paginated arrays");
+              }
+              const pulls = pages.flat();
+              const mergedMainPull = pulls.find((pull) =>
+                pull?.base?.ref === "main" &&
+                pull.state === "closed" &&
+                typeof pull.merged_at === "string" &&
+                pull.merged_at.length > 0,
+              );
+              if (!mergedMainPull) {
+                throw new Error(`commit ${process.env.GITHUB_SHA} is not associated with a merged pull request targeting main`);
+              }
+            });' || {
+            echo "Refusing to tag without proven merged pull request provenance." >&2
+            exit 1
+          }
+      - id: release
+        name: Detect a stable version change
+        env:
+          BEFORE: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          printf 'should_tag=false\n' >> "$GITHUB_OUTPUT"
+
+          if [[ "$BEFORE" =~ ^0{40}$ ]]; then
+            echo "Initial push has no comparable base; refusing to tag."
+            exit 0
+          fi
+          if ! git cat-file -e "$BEFORE^{commit}"; then
+            echo "Push base is unavailable; refusing to tag." >&2
+            exit 1
+          fi
+          if ! git merge-base --is-ancestor "$BEFORE" "$GITHUB_SHA"; then
+            echo "Push base is not an ancestor of the merged SHA; refusing to tag." >&2
+            exit 1
+          fi
+          if git diff --quiet "$BEFORE" "$GITHUB_SHA" -- package.json; then
+            echo "package.json did not change; this is an ordinary merge."
+            exit 0
+          fi
+
+          base_package="$(git show "$BEFORE:package.json")" || {
+            echo "The push base has no readable package.json; refusing to tag." >&2
+            exit 1
+          }
+          base_version="$(printf '%s' "$base_package" | node -e 'let source = ""; process.stdin.on("data", (chunk) => source += chunk).on("end", () => console.log(JSON.parse(source).version));')"
+          version="$(node -p 'require("./package.json").version')"
+          if [[ "$version" == *-* ]]; then
+            echo "Prerelease version $version is not taggable."
+            exit 0
+          fi
+          node scripts/validate-package.mjs --release-transition "$base_version" "$version"
+
+          printf 'should_tag=true\nversion=%s\n' "$version" >> "$GITHUB_OUTPUT"
+
+  tag:
+    name: Create release tag
+    needs: validate
+    if: needs.validate.outputs.should_tag == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Create immutable annotated tag
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="v$VERSION"
+          existing_refs_json="$(gh api --method GET \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "repos/$GITHUB_REPOSITORY/git/matching-refs/tags/$tag")" || {
+            echo "Could not determine whether tag $tag exists." >&2
+            exit 1
+          }
+          existing_tag_object_sha="$(printf '%s' "$existing_refs_json" | TAG="$tag" node -e '
+            let input = "";
+            process.stdin.on("data", (chunk) => input += chunk).on("end", () => {
+              const refs = JSON.parse(input);
+              if (!Array.isArray(refs)) throw new Error("matching refs API response is not an array");
+              const matches = refs.filter((ref) => ref?.ref === `refs/tags/${process.env.TAG}`);
+              if (matches.length > 1) throw new Error("matching refs API response has duplicate exact tag refs");
+              if (matches.length === 0) return;
+              const object = matches[0].object;
+              if (object?.type !== "tag" || typeof object.sha !== "string" || !/^[0-9a-f]{40}$/i.test(object.sha)) {
+                throw new Error("existing tag ref does not target an annotated tag object");
+              }
+              console.log(object.sha);
+            });')" || {
+            echo "Existing tag lookup was invalid or ambiguous." >&2
+            exit 1
+          }
+          if [[ -n "$existing_tag_object_sha" ]]; then
+            existing_tag_json="$(gh api --method GET \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "repos/$GITHUB_REPOSITORY/git/tags/$existing_tag_object_sha")" || {
+                echo "Could not inspect existing annotated tag object for $tag." >&2
+                exit 1
+              }
+            printf '%s' "$existing_tag_json" | TAG="$tag" GITHUB_SHA="$GITHUB_SHA" node -e '
+              let input = "";
+              process.stdin.on("data", (chunk) => input += chunk).on("end", () => {
+                const tagObject = JSON.parse(input);
+                if (tagObject.tag !== process.env.TAG || tagObject.object?.type !== "commit" || tagObject.object?.sha !== process.env.GITHUB_SHA) {
+                  throw new Error("existing annotated tag does not peel to the merged commit");
+                }
+              });' || {
+              echo "Refusing existing tag $tag because it is not the expected annotated tag at $GITHUB_SHA." >&2
+              exit 1
+            }
+            echo "Tag $tag already exists as an annotated tag at the merged SHA; rerun is a no-op."
+            exit 0
+          fi
+
+          tag_object_json="$(gh api --method POST "repos/$GITHUB_REPOSITORY/git/tags" \
+            -f tag="$tag" \
+            -f message="Release $tag" \
+            -f object="$GITHUB_SHA" \
+            -f type=commit)" || {
+            echo "Could not create annotated tag object for $tag." >&2
+            exit 1
+          }
+          tag_object_sha="$(printf '%s' "$tag_object_json" | TAG="$tag" node -e '
+            let input = "";
+            process.stdin.on("data", (chunk) => input += chunk).on("end", () => {
+              const tagObject = JSON.parse(input);
+              if (typeof tagObject.sha !== "string" || !/^[0-9a-f]{40}$/i.test(tagObject.sha)) {
+                throw new Error("annotated tag API response has no unambiguous SHA");
+              }
+              if (tagObject.tag !== process.env.TAG || tagObject.object?.type !== "commit" || tagObject.object?.sha !== process.env.GITHUB_SHA) {
+                throw new Error("annotated tag API response does not match the requested tag and commit");
+              }
+              console.log(tagObject.sha);
+            });')" || {
+            echo "Annotated tag API response was invalid or ambiguous." >&2
+            exit 1
+          }
+          ref_json="$(gh api --method POST "repos/$GITHUB_REPOSITORY/git/refs" \
+            -f ref="refs/tags/$tag" \
+            -f sha="$tag_object_sha")" || {
+            echo "Could not create ref refs/tags/$tag." >&2
+            exit 1
+          }
+          printf '%s' "$ref_json" | TAG="$tag" TAG_OBJECT_SHA="$tag_object_sha" node -e '
+            let input = "";
+            process.stdin.on("data", (chunk) => input += chunk).on("end", () => {
+              const ref = JSON.parse(input);
+              if (ref.ref !== `refs/tags/${process.env.TAG}` || ref.object?.type !== "tag" || ref.object?.sha !== process.env.TAG_OBJECT_SHA) {
+                throw new Error("tag ref API response does not match the requested annotated tag object");
+              }
+            });' || {
+            echo "Tag ref API response was invalid or ambiguous." >&2
+            exit 1
+          }

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .atl/
+.codegraph/
 .DS_Store
 Thumbs.db
 *.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+## Unreleased
+
+- Establish package validation, CI, and deliberate Git tag release foundations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ A release PR must update all of the following together:
 - `skills/mobile-agent-orchestrator/SKILL.md` metadata version
 - `CHANGELOG.md` with the stable version heading and release notes
 
-Stable releases must remove the README draft marker and replace its `<owner>` and `<tag>` installation placeholders. The package validator enforces these rules.
+Stable releases must remove the README draft marker and replace its `vX.Y.Z` future-install placeholder with the published stable tag. The package validator also rejects legacy `<owner>` and `<tag>` placeholders.
 
 ## Scope
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing
+
+Contributions should keep the skill safe, reviewable, and explicitly prerelease until release evidence exists.
+
+## Quick path
+
+1. Create a focused change from `main` and preserve the skill's safety contracts.
+2. Run `npm test` before requesting review.
+3. Keep ordinary changes untagged. A release PR is the only path that may create a GitHub release tag after merge.
+
+## Release PR checklist
+
+A release PR must update all of the following together:
+
+- `package.json` version
+- `skills/mobile-agent-orchestrator/SKILL.md` metadata version
+- `CHANGELOG.md` with the stable version heading and release notes
+
+Stable releases must remove the README draft marker and replace its `<owner>` and `<tag>` installation placeholders. The package validator enforces these rules.
+
+## Scope
+
+GitHub tags are the distribution channel. npm publication is out of scope. See the [release guide](docs/RELEASE.md) and [security policy](SECURITY.md).

--- a/LICENSE
+++ b/LICENSE
@@ -1,201 +1,21 @@
-Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+MIT License
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Copyright (c) 2026 egdev6
 
-   1. Definitions.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ Never put private keys, pairing tokens, sign-in URLs, QR contents, or credential
 - Moshi, `moshi-hook`, Mosh, Herdr or tmux, selected integrations, notifications, and checkpoints.
 - Windows WSL boot keepalive plus systemd linger, macOS lifecycle evidence, and disconnect/reboot recovery checks.
 
+## Maintainer documentation
+
+- [Contributing](CONTRIBUTING.md)
+- [Release guide](docs/RELEASE.md)
+- [Security policy](SECURITY.md)
+
+The package remains a draft prerelease. These documents define the intended validation and release process; they do not claim completed operational validation or published tags.
+
 ## License
 
 Apache-2.0. See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -42,4 +42,4 @@ The package remains a draft prerelease. These documents define the intended vali
 
 ## License
 
-Apache-2.0. See [LICENSE](LICENSE).
+MIT. See [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,45 +1,201 @@
-# Mobile Agent Orchestrator
+<a id="readme-top"></a>
 
-A Pi package that guides a human and an agent through a safe, persistent mobile AI-agent setup. It favors private-overlay access, explicit approvals, and recovery evidence over fast but fragile setup.
+<div align="center">
+  <a href="https://github.com/egdev6/mobile-agent-orchestrator">
+    <h1>Mobile Agent Orchestrator</h1>
+  </a>
 
-> **Status: draft.** Cold-boot behavior is pending evidence; this package does not claim a completed publication or a verified reboot-survival result.
+  <p>A guided Pi skill for a private, recoverable mobile AI-agent environment.</p>
 
-## Supported matrix
+  <p>
+    <a href="https://github.com/egdev6/mobile-agent-orchestrator/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/egdev6/mobile-agent-orchestrator/ci.yml?branch=main&amp;label=package%20CI&amp;style=for-the-badge" alt="Package CI"></a>
+    <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green?style=for-the-badge" alt="MIT License"></a>
+    <a href="https://pi.dev"><img src="https://img.shields.io/badge/Pi-package-7c3aed?style=for-the-badge" alt="Pi package"></a>
+    <img src="https://img.shields.io/badge/status-draft-orange?style=for-the-badge" alt="Draft status">
+  </p>
+</div>
 
-| Target | Status | Model |
+---
+
+> **Status: draft.** Version `0.1.0-dev.0` has no stable Git tag, npm publication, completed cold-boot evidence, or live operational-verification claim. Review the source before installation: a Pi skill can guide system and network changes.
+
+<details>
+  <summary>Table of Contents</summary>
+  <ol>
+    <li><a href="#prerequisites">Prerequisites</a></li>
+    <li><a href="#installation">Installation</a></li>
+    <li><a href="#usage">Usage</a></li>
+    <li><a href="#architecture">Architecture</a></li>
+    <li><a href="#features">Features</a></li>
+    <li><a href="#runtime-stack">Runtime Stack</a></li>
+    <li><a href="#safety-boundaries">Safety Boundaries</a></li>
+    <li><a href="#verification-and-recovery">Verification and Recovery</a></li>
+    <li><a href="#contributing-and-contact">Contributing and Contact</a></li>
+    <li><a href="#license">License</a></li>
+  </ol>
+</details>
+
+---
+
+## Built With
+
+<div align="center">
+  <a href="https://pi.dev"><img src="https://img.shields.io/badge/Pi-Coding%20Agent-7c3aed" alt="Pi Coding Agent"></a>
+  <a href="https://agentskills.io"><img src="https://img.shields.io/badge/Agent%20Skills-compatible-0f766e" alt="Agent Skills"></a>
+  <a href="https://nodejs.org"><img src="https://img.shields.io/badge/Node.js-ESM-339933" alt="Node.js ESM"></a>
+  <a href="https://www.npmjs.com"><img src="https://img.shields.io/badge/npm-package%20validation-CB3837" alt="npm"></a>
+  <a href="https://github.com/features/actions"><img src="https://img.shields.io/badge/GitHub-Actions-2088FF" alt="GitHub Actions"></a>
+</div>
+
+---
+
+## Prerequisites
+
+| Requirement | Why it matters |
+| --- | --- |
+| A reviewed local checkout and a working [Pi Coding Agent][pi] installation | Pi packages and skills can instruct an agent to make system changes. |
+| **macOS native** | Supported native lifecycle and execution target. |
+| **Windows 11 with WSL2** | Supported split model: Windows owns startup; the selected WSL distribution runs Linux services and agents. |
+| Windows native without WSL2 | **Unsupported.** Stop and install WSL2 before using this workflow. |
+
+The guided workflow discovers its runtime state before proposing changes. It installs runtime components only after the relevant approval; they are not bundled as npm dependencies.
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+## Installation
+
+### Safe draft path: install from a local checkout
+
+1. Review this repository, especially the [skill][skill] and its on-demand references.
+2. Install the reviewed local package:
+
+   ```bash
+   pi install /absolute/path/to/mobile-agent-orchestrator
+   ```
+
+3. Start Pi from your normal working directory.
+
+### Future stable Git path
+
+> **Available only after a stable Git tag exists.** This draft has no stable tag today.
+
+```bash
+pi install git:github.com/egdev6/mobile-agent-orchestrator@vX.Y.Z
+```
+
+Replace `vX.Y.Z` with the published stable tag. Git tags—not npm publication—are this project's intended distribution channel. See the [release guide][release-guide] for the release conditions.
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+## Usage
+
+Use the skill from an active Pi session:
+
+```text
+/skill:mobile-agent-orchestrator
+```
+
+A matching natural-language request, such as “set up a private mobile Pi environment with Tailscale and Mosh,” can also load the skill. Follow the guided path rather than running an installation recipe out of order:
+
+1. **Detect:** allow read-only platform and state checks; unsupported or unclear targets stop safely.
+2. **Decide:** answer only real decision gates, including Tailscale placement, key setup, Moshi privacy, integrations, and notifications.
+3. **Approve:** explicitly authorize each privileged, network, service, firewall, pairing, lifecycle, or reboot mutation before it happens.
+4. **Verify:** collect non-sensitive checkpoints after each approved mutation and use the [recovery guide][verification-recovery] when a check fails.
+
+The skill is a human-supervised orchestrator, not an unattended installer. Platform detail lives in the [platform matrix][platform-matrix] and [guided install][guided-install] reference so the core workflow stays concise.
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+## Architecture
+
+```text
+mobile-agent-orchestrator/
+├── package.json
+│   └── pi.skills: ./skills ──> Pi package discovery
+├── skills/mobile-agent-orchestrator/
+│   ├── SKILL.md ────────────> activation contract, decision gates, safe orchestration
+│   └── references/ ─────────> loaded on demand: platform, installation, recovery
+├── scripts/validate-package.mjs
+│   └── Node.js ESM validator ──> metadata, package contents, local Markdown links
+└── .github/workflows/
+    ├── ci.yml ──────────────> npm test on pull requests and main
+    └── tag-release.yml ─────> validated, merged-PR-only stable Git tags
+```
+
+Pi discovers the package's `skills/` directory through the `pi.skills` manifest. The `SKILL.md` file uses Agent Skills-compatible Markdown and YAML frontmatter; its references are deliberately loaded only when the workflow needs their detail. The validator and GitHub Actions verify the package and gate future tags, but they do not certify a live remote-agent deployment.
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+## Features
+
+| Area | What the skill guides |
+| --- | --- |
+| Platform routing | macOS native or Windows 11 + WSL2 detection, with a safe stop for unsupported Windows-native paths. |
+| Private access | Tailscale overlay placement, constrained OpenSSH exposure, and mobile-client pairing without copying secrets into chat. |
+| Session continuity | Mosh with Moshi and `moshi-hook`, plus Herdr when supported or tmux as the fallback terminal host. |
+| Lifecycle planning | Supported WSL systemd, linger, and Windows-startup considerations; macOS mechanisms only after current official documentation and local evidence. |
+| Human control | Read-only discovery, one real decision at a time, explicit approval before sensitive changes, and local recovery preserved. |
+| Evidence and rollback | Non-sensitive verification checkpoints, disconnect and approved reboot checks, and mutation-scoped rollback guidance. |
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+## Runtime Stack
+
+The package implementation and the remote environment it orchestrates are separate layers.
+
+| Layer | Components | Responsibility |
 | --- | --- | --- |
-| macOS native | Supported | Native lifecycle host and execution environment |
-| Windows 11 + WSL2 | Supported | Windows owns lifecycle; WSL runs Linux services and agents |
-| Windows native without WSL | Unsupported | Stop and install WSL2 first |
+| **Package implementation** | Pi package manifest, Agent Skills-compatible Markdown/YAML frontmatter, Node.js ESM validator, npm, GitHub Actions | Discovers the skill, validates package metadata and contents, and runs CI/release checks. |
+| **Orchestrated runtime** | Tailscale, OpenSSH, Mosh, Moshi/`moshi-hook`, Herdr or tmux | Provides the private mobile connection and persistent-session workflow on the selected target. |
+| **Platform lifecycle** | Windows 11 + WSL2 systemd/linger/startup mechanisms, or macOS lifecycle mechanisms | Starts only the specifically approved services using current platform documentation. |
 
-## Quick path
+Tailscale, OpenSSH, Mosh, Moshi, `moshi-hook`, Herdr, tmux, and platform lifecycle tooling are **runtime dependencies installed by the guided workflow**. They are not package-bundled npm dependencies, and their exact installation route is chosen from current signed vendor or platform documentation after approval.
 
-1. Review this repository before installation; skills can direct system changes.
-2. Try the local checkout: `pi install /path/to/mobile-agent-orchestrator`.
-3. After a maintainer publishes a tagged remote, install it with `pi install git:github.com/<owner>/mobile-agent-orchestrator@<tag>`.
-4. In Pi, invoke the `mobile-agent-orchestrator` skill and answer only the detected decision gates.
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
 
-The skill keeps its detailed, platform-specific flow in `skills/mobile-agent-orchestrator/references/`.
+## Safety Boundaries
 
-## Privacy and safety
+- Never open public SSH access or add router port forwarding; constrain any listener before enabling it.
+- Keep Tailscale SSH disabled for the Moshi/OpenSSH key-authentication route.
+- For the full-Mosh Windows route, run Tailscale in exactly one location: **WSL**, not Windows and WSL together. On macOS, use macOS as the single location.
+- Do not place private keys, pairing tokens, sign-in URLs, QR data, or credentials in chat, shell history, or repository files. QR data is temporary secret material.
+- Require explicit approval before privileged installation, authentication or firewall changes, cloud pairing, service/task creation, reboot, or destructive rollback.
+- Preserve a local recovery path, validate SSH configuration before reload, test a second key-authenticated session, and record non-sensitive rollback evidence.
 
-Never put private keys, pairing tokens, sign-in URLs, QR contents, or credentials in chat, shell history, or repository files. Pair on the device or use hidden terminal input. Do not expose SSH through a public IP or router forwarding rule. For the full-Mosh route, run Tailscale in exactly one place: macOS, or WSL—not both Windows and WSL.
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
 
-## What the guide covers
+## Verification and Recovery
 
-- Platform preflight, permissions, rollback, firewall boundaries, and OpenSSH hardening.
-- Tailscale on the execution target and on Android/iOS, with Tailscale SSH disabled.
-- Moshi, `moshi-hook`, Mosh, Herdr or tmux, selected integrations, notifications, and checkpoints.
-- Windows WSL boot keepalive plus systemd linger, macOS lifecycle evidence, and disconnect/reboot recovery checks.
+After each approved mutation, the workflow captures non-sensitive evidence for the private overlay, key-authenticated SSH, Mosh reconnection, session host, checkpoints, integrations, and notifications. A missing component or failed check is a finding—not authorization to make another change.
 
-## Maintainer documentation
+Before an approved reboot, the guide states that live processes will die, confirms recovery and rollback paths, then checks the actual post-reboot state. Herdr and tmux do not preserve live processes across a physical reboot; supported Pi JSONL sessions may resume from local disk. Cold-boot behavior remains pending human-observed evidence in this draft.
 
-- [Contributing](CONTRIBUTING.md)
-- [Release guide](docs/RELEASE.md)
-- [Security policy](SECURITY.md)
+Read the full [verification and recovery guide][verification-recovery] before applying lifecycle or rollback changes.
 
-The package remains a draft prerelease. These documents define the intended validation and release process; they do not claim completed operational validation or published tags.
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+## Contributing and Contact
+
+- [Contributing][contributing] — focused changes, test expectations, and release-PR rules.
+- [Release guide][release-guide] — Git-tag distribution and stable-release guardrails.
+- [Security policy][security] — report vulnerabilities privately; never include secrets in an issue.
+- [Issue tracker][issues] — report non-sensitive bugs and feature requests.
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 ## License
 
-MIT. See [LICENSE](LICENSE).
+Distributed under the [MIT License][license].
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+[pi]: https://pi.dev
+[skill]: skills/mobile-agent-orchestrator/SKILL.md
+[platform-matrix]: skills/mobile-agent-orchestrator/references/platform-matrix.md
+[guided-install]: skills/mobile-agent-orchestrator/references/guided-install.md
+[verification-recovery]: skills/mobile-agent-orchestrator/references/verification-and-recovery.md
+[contributing]: CONTRIBUTING.md
+[release-guide]: docs/RELEASE.md
+[security]: SECURITY.md
+[license]: LICENSE
+[issues]: https://github.com/egdev6/mobile-agent-orchestrator/issues

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report suspected vulnerabilities privately through the repository's [security advisories](https://github.com/egdev6/mobile-agent-orchestrator/security/advisories/new). Do not include credentials, private keys, pairing tokens, sign-in URLs, or QR contents in a public issue.
+
+Include a concise impact description, affected revision, reproduction steps, and any safe mitigation you identified. Maintainers will acknowledge the report and coordinate a private resolution when needed.
+
+## Scope
+
+This prerelease skill can guide system, network, and authentication changes. Security reports covering unsafe guidance, secret handling, network exposure, or release-distribution integrity are in scope.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,25 @@
+# Release Guide
+
+GitHub tags are this project's distribution channel. npm publication is out of scope.
+
+## Release path
+
+1. Open a dedicated release PR. Ordinary merges to `main` never create a tag.
+2. Update `package.json` and `skills/mobile-agent-orchestrator/SKILL.md` to the same stable version.
+3. Add a matching stable-version heading and release notes to `CHANGELOG.md`.
+4. Remove the README draft marker and replace the `<owner>` and `<tag>` placeholders.
+5. Run `npm test`, review the release PR, and merge it into `main`.
+
+After the merge, the workflow uses GitHub's pull-request association API to prove that `GITHUB_SHA` belongs to a merged pull request targeting `main`. It then validates the merged revision, confirms that `package.json` has a real stable-version change from the pushed base, and creates one annotated tag object and its immutable `vX.Y.Z` ref through the GitHub API.
+
+## Guardrails
+
+- Prerelease versions such as `0.1.0-dev.0` are never tagged.
+- A rerun is a successful no-op only when the existing ref targets an annotated tag object whose peeled commit is the merged SHA; lightweight or conflicting tags fail rather than being replaced.
+- The workflow creates annotated tag objects and refs through the GitHub API; it does not use `git push` to create tags.
+- The workflow does not itself prevent direct pushes to `main`; branch protection is configured externally. Direct pushes cannot create a release tag because the workflow fails closed without proven merged-pull-request provenance.
+- Do not create a tag manually for this workflow; tags are immutable release records.
+
+## Verification
+
+Use `npm test` to validate metadata, skill packaging, local Markdown links, the npm dry-run file list, and stable-release requirements. This foundation does not claim a published tag or completed operational validation.

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -7,7 +7,7 @@ GitHub tags are this project's distribution channel. npm publication is out of s
 1. Open a dedicated release PR. Ordinary merges to `main` never create a tag.
 2. Update `package.json` and `skills/mobile-agent-orchestrator/SKILL.md` to the same stable version.
 3. Add a matching stable-version heading and release notes to `CHANGELOG.md`.
-4. Remove the README draft marker and replace the `<owner>` and `<tag>` placeholders.
+4. Remove the README draft marker and replace the `vX.Y.Z` future-install placeholder with the published stable tag. The validator also rejects legacy `<owner>` and `<tag>` placeholders.
 5. Run `npm test`, review the release PR, and merge it into `main`.
 
 After the merge, the workflow uses GitHub's pull-request association API to prove that `GITHUB_SHA` belongs to a merged pull request targeting `main`. It then validates the merged revision, confirms that `package.json` has a real stable-version change from the pushed base, and creates one annotated tag object and its immutable `vX.Y.Z` ref through the GitHub API.

--- a/package.json
+++ b/package.json
@@ -1,9 +1,26 @@
 {
   "name": "mobile-agent-orchestrator",
-  "version": "0.1.0",
+  "version": "0.1.0-dev.0",
   "description": "A guided Pi skill for safely setting up a persistent mobile AI-agent environment.",
   "license": "Apache-2.0",
   "private": false,
+  "author": "egdev6",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/egdev6/mobile-agent-orchestrator.git"
+  },
+  "homepage": "https://github.com/egdev6/mobile-agent-orchestrator",
+  "bugs": {
+    "url": "https://github.com/egdev6/mobile-agent-orchestrator/issues"
+  },
+  "files": [
+    "skills/"
+  ],
+  "scripts": {
+    "validate": "node scripts/validate-package.mjs",
+    "pack:check": "npm pack --dry-run --json",
+    "test": "npm run validate"
+  },
   "keywords": [
     "pi-package",
     "pi-skill",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mobile-agent-orchestrator",
   "version": "0.1.0-dev.0",
   "description": "A guided Pi skill for safely setting up a persistent mobile AI-agent environment.",
-  "license": "Apache-2.0",
+  "license": "MIT",
   "private": false,
   "author": "egdev6",
   "repository": {

--- a/scripts/validate-package.mjs
+++ b/scripts/validate-package.mjs
@@ -1,0 +1,458 @@
+#!/usr/bin/env node
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { dirname, extname, relative, resolve, sep } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const semverPattern = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/;
+const requiredSections = [
+  "Activation Contract",
+  "Hard Rules",
+  "Decision Gates",
+  "Execution Steps",
+  "Output Contract",
+  "References",
+];
+
+export function parseSemVer(version) {
+  if (typeof version !== "string") return null;
+  const match = version.match(semverPattern);
+  if (!match) return null;
+  return {
+    major: match[1],
+    minor: match[2],
+    patch: match[3],
+    prerelease: match[4]?.split(".") ?? [],
+    build: match[5]?.split(".") ?? [],
+  };
+}
+
+function compareNumericIdentifiers(left, right) {
+  if (left.length !== right.length) return left.length < right.length ? -1 : 1;
+  if (left === right) return 0;
+  return left < right ? -1 : 1;
+}
+
+export function compareSemVer(left, right) {
+  const leftVersion = typeof left === "string" ? parseSemVer(left) : left;
+  const rightVersion = typeof right === "string" ? parseSemVer(right) : right;
+  if (!leftVersion || !rightVersion) {
+    throw new Error("SemVer comparison requires two valid SemVer versions.");
+  }
+
+  for (const key of ["major", "minor", "patch"]) {
+    const comparison = compareNumericIdentifiers(leftVersion[key], rightVersion[key]);
+    if (comparison !== 0) return comparison;
+  }
+  if (leftVersion.prerelease.length === 0 || rightVersion.prerelease.length === 0) {
+    if (leftVersion.prerelease.length === rightVersion.prerelease.length) return 0;
+    return leftVersion.prerelease.length === 0 ? 1 : -1;
+  }
+
+  const length = Math.max(leftVersion.prerelease.length, rightVersion.prerelease.length);
+  for (let index = 0; index < length; index += 1) {
+    const leftIdentifier = leftVersion.prerelease[index];
+    const rightIdentifier = rightVersion.prerelease[index];
+    if (leftIdentifier === undefined) return -1;
+    if (rightIdentifier === undefined) return 1;
+    if (leftIdentifier === rightIdentifier) continue;
+
+    const leftNumeric = /^\d+$/.test(leftIdentifier);
+    const rightNumeric = /^\d+$/.test(rightIdentifier);
+    if (leftNumeric && rightNumeric) {
+      return compareNumericIdentifiers(leftIdentifier, rightIdentifier);
+    }
+    if (leftNumeric !== rightNumeric) return leftNumeric ? -1 : 1;
+    return leftIdentifier < rightIdentifier ? -1 : 1;
+  }
+  return 0;
+}
+
+export function assertReleaseTransition(baseVersion, releaseVersion) {
+  const base = parseSemVer(baseVersion);
+  const release = parseSemVer(releaseVersion);
+  if (!base) throw new Error(`Base version is not valid SemVer: ${JSON.stringify(baseVersion)}.`);
+  if (!release) throw new Error(`Release version is not valid SemVer: ${JSON.stringify(releaseVersion)}.`);
+  if (release.prerelease.length > 0) {
+    throw new Error(`Release version must be stable, not prerelease: ${releaseVersion}.`);
+  }
+  if (release.build.length > 0) {
+    throw new Error(`Stable release version must not contain build metadata: ${releaseVersion}.`);
+  }
+  if (compareSemVer(base, release) >= 0) {
+    throw new Error(`Release version must strictly increase SemVer precedence: ${baseVersion} -> ${releaseVersion}.`);
+  }
+}
+
+export function parseSkillFrontmatter(skill) {
+  const lines = skill.replace(/\r\n/g, "\n").split("\n");
+  if (lines[0] !== "---") {
+    throw new Error("SKILL.md must start with a frontmatter delimiter.");
+  }
+  const closingIndex = lines.indexOf("---", 1);
+  if (closingIndex === -1) {
+    throw new Error("SKILL.md frontmatter must have a closing delimiter.");
+  }
+
+  const expectedTopLevel = ["name", "description", "license", "metadata"];
+  const expectedMetadata = ["author", "version"];
+  const frontmatter = {};
+  let topIndex = 0;
+  let metadataIndex = 0;
+  let inMetadata = false;
+
+  for (let index = 1; index < closingIndex; index += 1) {
+    const line = lines[index];
+    const number = index + 1;
+    if (!line) throw new Error(`SKILL.md frontmatter line ${number} must not be blank.`);
+    if (line.includes("\t")) throw new Error(`SKILL.md frontmatter line ${number} must not contain tabs.`);
+
+    const topLevel = line.match(/^([a-z][a-z-]*):(?: (.*))?$/);
+    const nested = line.match(/^ {2}([a-z][a-z-]*): (.+)$/);
+    if (topLevel) {
+      const [, key, rawValue] = topLevel;
+      if (key !== expectedTopLevel[topIndex]) {
+        throw new Error(`SKILL.md frontmatter line ${number} has unexpected or duplicate top-level key: ${key}.`);
+      }
+      topIndex += 1;
+      if (key === "metadata") {
+        if (rawValue !== undefined) {
+          throw new Error("SKILL.md metadata must be a mapping, not a scalar.");
+        }
+        inMetadata = true;
+        frontmatter.metadata = {};
+      } else {
+        if (inMetadata || rawValue === undefined || rawValue === "") {
+          throw new Error(`SKILL.md frontmatter key ${key} must have a scalar value.`);
+        }
+        frontmatter[key] = parseYamlScalar(rawValue, number);
+      }
+      continue;
+    }
+    if (nested) {
+      const [, key, rawValue] = nested;
+      if (!inMetadata || key !== expectedMetadata[metadataIndex]) {
+        throw new Error(`SKILL.md frontmatter line ${number} has unexpected, duplicate, or misplaced nested key: ${key}.`);
+      }
+      metadataIndex += 1;
+      frontmatter.metadata[key] = parseYamlScalar(rawValue, number);
+      continue;
+    }
+    throw new Error(`SKILL.md frontmatter line ${number} has unsupported YAML structure.`);
+  }
+
+  if (topIndex !== expectedTopLevel.length || metadataIndex !== expectedMetadata.length) {
+    throw new Error("SKILL.md frontmatter must define name, description, license, metadata.author, and metadata.version exactly once.");
+  }
+  return { frontmatter, body: lines.slice(closingIndex + 1) };
+}
+
+function parseYamlScalar(value, lineNumber) {
+  if (value.startsWith('"')) {
+    try {
+      const parsed = JSON.parse(value);
+      if (typeof parsed !== "string") throw new Error("not a string");
+      return parsed;
+    } catch {
+      throw new Error(`SKILL.md frontmatter line ${lineNumber} has an invalid double-quoted scalar.`);
+    }
+  }
+  if (value.startsWith("'")) {
+    const match = value.match(/^'((?:[^']|'')*)'$/);
+    if (!match) throw new Error(`SKILL.md frontmatter line ${lineNumber} has an invalid single-quoted scalar.`);
+    return match[1].replaceAll("''", "'");
+  }
+  if (!/^[^\s#][^#]*\S$|^[^\s#]$/.test(value) || /[:[\]{}&,*!|>@`]/.test(value)) {
+    throw new Error(`SKILL.md frontmatter line ${lineNumber} has an unsupported plain scalar.`);
+  }
+  return value;
+}
+
+export function validateRequiredSections(body) {
+  const occurrences = new Map(requiredSections.map((section) => [section, []]));
+  let fence = null;
+
+  for (let index = 0; index < body.length; index += 1) {
+    const line = body[index];
+    const fenceMatch = line.match(/^ {0,3}(`{3,}|~{3,})/);
+    if (fenceMatch) {
+      const marker = fenceMatch[1];
+      if (!fence) fence = { character: marker[0], length: marker.length };
+      else if (marker[0] === fence.character && marker.length >= fence.length) fence = null;
+      continue;
+    }
+    if (fence) continue;
+    for (const section of requiredSections) {
+      if (line === `## ${section}`) occurrences.get(section).push(index + 1);
+    }
+  }
+
+  const positions = [];
+  for (const section of requiredSections) {
+    const matches = occurrences.get(section);
+    if (matches.length !== 1) {
+      throw new Error(`SKILL.md must contain exactly one level-2 heading: ## ${section}.`);
+    }
+    positions.push(matches[0]);
+  }
+  for (let index = 1; index < positions.length; index += 1) {
+    if (positions[index] <= positions[index - 1]) {
+      throw new Error(`SKILL.md required level-2 headings are out of order at: ${requiredSections[index]}.`);
+    }
+  }
+}
+
+export function decodeLocalDestination(destination) {
+  try {
+    return decodeURIComponent(destination.split(/[?#]/, 1)[0]);
+  } catch {
+    throw new Error(`Malformed percent encoding in local Markdown target: ${destination}.`);
+  }
+}
+
+function walk(directory, predicate) {
+  const results = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    if ([".git", "node_modules", ".codegraph"].includes(entry.name)) continue;
+    const path = resolve(directory, entry.name);
+    if (entry.isDirectory()) results.push(...walk(path, predicate));
+    else if (predicate(path)) results.push(path);
+  }
+  return results;
+}
+
+function validateLocalTarget(markdownPath, destination, fail) {
+  if (!destination || destination.startsWith("#") || /^(?:[a-z][a-z\d+.-]*:|\/\/)/i.test(destination)) {
+    return;
+  }
+  let localPath;
+  try {
+    localPath = decodeLocalDestination(destination);
+  } catch (error) {
+    fail(`${relative(root, markdownPath)}: ${error.message}`);
+    return;
+  }
+  if (!localPath) return;
+
+  const target = localPath.startsWith("/")
+    ? resolve(root, `.${localPath}`)
+    : resolve(dirname(markdownPath), localPath);
+  const targetRelative = relative(root, target);
+  if (
+    targetRelative === ".." ||
+    targetRelative.startsWith(`..${sep}`) ||
+    !existsSync(target)
+  ) {
+    fail(`${relative(root, markdownPath)} links to a missing local path: ${destination}.`);
+  }
+}
+
+function validateLocalMarkdownLinks(fail) {
+  const markdownFiles = walk(root, (path) => extname(path).toLowerCase() === ".md");
+  const inlinePattern = /!?\[[^\]]*\]\(\s*(?:<([^>]+)>|([^\s)]+))[^)]*\)/g;
+  const referencePattern = /^ {0,3}\[[^\]]+\]:\s*(?:<([^>]+)>|([^\s]+))(?:\s+.*)?$/gm;
+
+  for (const markdownPath of markdownFiles) {
+    const content = readFileSync(markdownPath, "utf8");
+    for (const match of content.matchAll(inlinePattern)) {
+      validateLocalTarget(markdownPath, match[1] ?? match[2], fail);
+    }
+    for (const match of content.matchAll(referencePattern)) {
+      validateLocalTarget(markdownPath, match[1] ?? match[2], fail);
+    }
+  }
+}
+
+function runNpmPack(packageName, fail) {
+  const result = spawnSync("npm", ["pack", "--dry-run", "--json"], {
+    cwd: root,
+    encoding: "utf8",
+  });
+  if (result.error) {
+    fail(`Could not run npm pack --dry-run --json: ${result.error.message}`);
+    return [];
+  }
+  if (result.status !== 0) {
+    fail(`npm pack --dry-run --json failed with exit ${result.status}: ${(result.stderr || result.stdout).trim()}`);
+    return [];
+  }
+
+  let output;
+  try {
+    output = JSON.parse(result.stdout);
+  } catch (error) {
+    fail(`npm pack --dry-run --json returned invalid JSON: ${error.message}`);
+    return [];
+  }
+
+  let entries = [];
+  if (Array.isArray(output)) {
+    entries = output;
+  } else if (output && typeof output === "object" && Array.isArray(output.files)) {
+    entries = [output];
+  } else if (output && typeof output === "object") {
+    entries = Object.values(output).filter(
+      (entry) => entry && typeof entry === "object" && Array.isArray(entry.files),
+    );
+  }
+
+  const entry = entries.find((candidate) => candidate.name === packageName);
+  if (!entry?.files) {
+    fail(`npm pack --dry-run --json returned no files for ${packageName}.`);
+    return [];
+  }
+  return entry.files.map((file) => (typeof file === "string" ? file : file.path));
+}
+
+export function compareTarballFiles(actualFiles, expectedFiles) {
+  const errors = [];
+  const expected = new Set(expectedFiles);
+  const actual = new Set();
+  for (const file of actualFiles) {
+    if (typeof file !== "string" || !file) errors.push("npm pack --dry-run --json returned a file without a path.");
+    else if (actual.has(file)) errors.push(`npm pack --dry-run --json returned a duplicate file path: ${file}.`);
+    else actual.add(file);
+  }
+  for (const file of expected) {
+    if (!actual.has(file)) errors.push(`npm package is missing allowlisted file: ${file}.`);
+  }
+  for (const file of actual) {
+    if (!expected.has(file)) errors.push(`npm package contains a non-allowlisted file: ${file}.`);
+  }
+  return errors;
+}
+
+function validateTarball(packageName, fail) {
+  const packedFiles = runNpmPack(packageName, fail);
+  if (packedFiles.length === 0) return;
+
+  const expectedFiles = [
+    "LICENSE",
+    "README.md",
+    "package.json",
+    "skills/mobile-agent-orchestrator/SKILL.md",
+    "skills/mobile-agent-orchestrator/references/guided-install.md",
+    "skills/mobile-agent-orchestrator/references/platform-matrix.md",
+    "skills/mobile-agent-orchestrator/references/verification-and-recovery.md",
+  ];
+  for (const error of compareTarballFiles(packedFiles, expectedFiles)) fail(error);
+}
+
+function validatePackage() {
+  const errors = [];
+  const fail = (message) => errors.push(message);
+  const packagePath = resolve(root, "package.json");
+  const skillPath = resolve(root, "skills/mobile-agent-orchestrator/SKILL.md");
+  const changelogPath = resolve(root, "CHANGELOG.md");
+  const readmePath = resolve(root, "README.md");
+  let packageJson = null;
+
+  try {
+    packageJson = JSON.parse(readFileSync(packagePath, "utf8"));
+  } catch (error) {
+    fail(`package.json must contain valid JSON: ${error.message}`);
+  }
+
+  if (packageJson) {
+    const expectedRepository = "https://github.com/egdev6/mobile-agent-orchestrator";
+    const version = parseSemVer(packageJson.version);
+    if (packageJson.name !== "mobile-agent-orchestrator") fail("package.json name must be mobile-agent-orchestrator.");
+    if (typeof packageJson.description !== "string" || !packageJson.description.trim()) fail("package.json must include a non-empty description.");
+    if (packageJson.license !== "Apache-2.0") fail("package.json license must be Apache-2.0.");
+    if (!version) fail(`package.json version must be valid SemVer; received ${JSON.stringify(packageJson.version)}.`);
+    if (version && version.prerelease.length === 0 && version.build.length > 0) {
+      fail("Stable package versions must not contain build metadata.");
+    }
+    if (typeof packageJson.author !== "string" || !packageJson.author.trim()) fail("package.json must include a non-empty public author string.");
+
+    const repositoryUrl = typeof packageJson.repository === "string" ? packageJson.repository : packageJson.repository?.url;
+    const normalizedRepository = repositoryUrl?.replace(/^git\+/, "").replace(/\.git$/, "");
+    if (normalizedRepository !== expectedRepository) fail(`package.json repository must be ${expectedRepository}.`);
+    if (packageJson.homepage !== expectedRepository) fail(`package.json homepage must be ${expectedRepository}.`);
+    if (packageJson.bugs?.url !== `${expectedRepository}/issues`) fail(`package.json bugs.url must be ${expectedRepository}/issues.`);
+    if (!Array.isArray(packageJson.files) || packageJson.files.length !== 1 || packageJson.files[0] !== "skills/") {
+      fail('package.json files must allowlist only "skills/".');
+    }
+    const requiredKeywords = ["pi-package", "pi-skill", "mobile-agent", "tailscale", "mosh"];
+    if (!Array.isArray(packageJson.keywords) || requiredKeywords.some((keyword) => !packageJson.keywords.includes(keyword))) {
+      fail("package.json keywords must preserve the Pi and mobile-agent discovery terms.");
+    }
+    if (!Array.isArray(packageJson.pi?.skills) || packageJson.pi.skills.length === 0) {
+      fail("package.json pi.skills must be a non-empty array.");
+    } else {
+      for (const target of packageJson.pi.skills) {
+        const resolvedTarget = typeof target === "string" ? resolve(root, target) : "";
+        const targetRelative = resolvedTarget && relative(root, resolvedTarget);
+        if (typeof target !== "string" || targetRelative === ".." || targetRelative.startsWith(`..${sep}`) || !existsSync(resolvedTarget)) {
+          fail(`package.json pi.skills target does not exist inside the package: ${JSON.stringify(target)}.`);
+        }
+      }
+    }
+  }
+
+  if (existsSync(skillPath)) {
+    try {
+      const parsedSkill = parseSkillFrontmatter(readFileSync(skillPath, "utf8"));
+      const { frontmatter } = parsedSkill;
+      if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(frontmatter.name) || frontmatter.name.length > 64) {
+        fail("SKILL.md name must be 1-64 lowercase letters, numbers, and single hyphens.");
+      }
+      if (!frontmatter.description || frontmatter.description.length > 1024) {
+        fail("SKILL.md description must be non-empty and at most 1024 characters.");
+      }
+      if (frontmatter.license !== "Apache-2.0") fail("SKILL.md license must be Apache-2.0.");
+      if (!frontmatter.metadata.author) fail("SKILL.md metadata.author must be non-empty.");
+      if (packageJson && frontmatter.metadata.version !== packageJson.version) {
+        fail(`SKILL.md metadata.version (${frontmatter.metadata.version}) must equal package.json version (${packageJson.version}).`);
+      }
+      validateRequiredSections(parsedSkill.body);
+    } catch (error) {
+      fail(error.message);
+    }
+  } else {
+    fail("Pi skill manifest is missing: skills/mobile-agent-orchestrator/SKILL.md.");
+  }
+
+  validateLocalMarkdownLinks(fail);
+
+  if (packageJson && !packageJson.version.includes("-")) {
+    const changelog = existsSync(changelogPath) ? readFileSync(changelogPath, "utf8") : "";
+    const readme = existsSync(readmePath) ? readFileSync(readmePath, "utf8") : "";
+    const escapedVersion = packageJson.version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    if (!new RegExp(`^##\\s+(?:\\[${escapedVersion}\\]|${escapedVersion})(?:\\s|$)`, "m").test(changelog)) {
+      fail(`Stable version ${packageJson.version} requires a matching CHANGELOG.md heading.`);
+    }
+    if (/\*\*Status:\s*draft\.\*\*/i.test(readme)) fail("Stable versions must remove the README draft marker.");
+    if (/<owner>|<tag>/.test(readme)) fail("Stable versions must replace README <owner> and <tag> placeholders.");
+  }
+
+  if (packageJson) validateTarball(packageJson.name, fail);
+
+  if (errors.length > 0) {
+    console.error("Package validation failed:");
+    for (const error of errors) console.error(`- ${error}`);
+    return 1;
+  }
+  console.log("Package validation passed.");
+  return 0;
+}
+
+function main() {
+  if (process.argv[2] === "--release-transition") {
+    try {
+      assertReleaseTransition(process.argv[3], process.argv[4]);
+      console.log(`Valid release transition: ${process.argv[3]} -> ${process.argv[4]}.`);
+      return 0;
+    } catch (error) {
+      console.error(`Invalid release transition: ${error.message}`);
+      return 1;
+    }
+  }
+  return validatePackage();
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  process.exitCode = main();
+}

--- a/scripts/validate-package.mjs
+++ b/scripts/validate-package.mjs
@@ -360,7 +360,7 @@ function validatePackage() {
     const version = parseSemVer(packageJson.version);
     if (packageJson.name !== "mobile-agent-orchestrator") fail("package.json name must be mobile-agent-orchestrator.");
     if (typeof packageJson.description !== "string" || !packageJson.description.trim()) fail("package.json must include a non-empty description.");
-    if (packageJson.license !== "Apache-2.0") fail("package.json license must be Apache-2.0.");
+    if (packageJson.license !== "MIT") fail("package.json license must be MIT.");
     if (!version) fail(`package.json version must be valid SemVer; received ${JSON.stringify(packageJson.version)}.`);
     if (version && version.prerelease.length === 0 && version.build.length > 0) {
       fail("Stable package versions must not contain build metadata.");
@@ -402,7 +402,7 @@ function validatePackage() {
       if (!frontmatter.description || frontmatter.description.length > 1024) {
         fail("SKILL.md description must be non-empty and at most 1024 characters.");
       }
-      if (frontmatter.license !== "Apache-2.0") fail("SKILL.md license must be Apache-2.0.");
+      if (frontmatter.license !== "MIT") fail("SKILL.md license must be MIT.");
       if (!frontmatter.metadata.author) fail("SKILL.md metadata.author must be non-empty.");
       if (packageJson && frontmatter.metadata.version !== packageJson.version) {
         fail(`SKILL.md metadata.version (${frontmatter.metadata.version}) must equal package.json version (${packageJson.version}).`);

--- a/scripts/validate-package.mjs
+++ b/scripts/validate-package.mjs
@@ -425,7 +425,9 @@ function validatePackage() {
       fail(`Stable version ${packageJson.version} requires a matching CHANGELOG.md heading.`);
     }
     if (/\*\*Status:\s*draft\.\*\*/i.test(readme)) fail("Stable versions must remove the README draft marker.");
-    if (/<owner>|<tag>/.test(readme)) fail("Stable versions must replace README <owner> and <tag> placeholders.");
+    if (/vX\.Y\.Z|<owner>|<tag>/.test(readme)) {
+      fail("Stable versions must replace README vX.Y.Z, <owner>, and <tag> installation placeholders.");
+    }
   }
 
   if (packageJson) validateTarball(packageJson.name, fail);

--- a/skills/mobile-agent-orchestrator/SKILL.md
+++ b/skills/mobile-agent-orchestrator/SKILL.md
@@ -4,7 +4,7 @@ description: "Trigger: mobile agent setup, mobile orchestrator, Moshi, Mosh, Tai
 license: Apache-2.0
 metadata:
   author: egdev6
-  version: "0.1.0"
+  version: "0.1.0-dev.0"
 ---
 
 ## Activation Contract

--- a/skills/mobile-agent-orchestrator/SKILL.md
+++ b/skills/mobile-agent-orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: mobile-agent-orchestrator
 description: "Trigger: mobile agent setup, mobile orchestrator, Moshi, Mosh, Tailscale, remote Pi. Guide a human through a safe persistent mobile AI-agent installation."
-license: Apache-2.0
+license: MIT
 metadata:
   author: egdev6
   version: "0.1.0-dev.0"


### PR DESCRIPTION
Closes #1

## PR type

- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Add deterministic package validation, CI enforcement, and immutable annotated-tag automation with merged-PR provenance.
- Adopt the MIT License consistently across package metadata, skill metadata, public documentation, and validation.
- Redesign the README with current Pi installation, usage, architecture, runtime stack, safety, and recovery guidance.

## Changes

| File | Change |
|------|--------|
| `package.json`, `scripts/validate-package.mjs` | Define package metadata and deterministic validation, including MIT and stable-placeholder requirements. |
| `.github/workflows/ci.yml` | Validate pull requests and `main` without persisting checkout credentials. |
| `.github/workflows/tag-release.yml` | Validate stable release transitions and create commit-bound annotated tags through GitHub APIs. |
| `LICENSE`, `skills/mobile-agent-orchestrator/SKILL.md` | Adopt MIT and keep skill metadata aligned with the package. |
| `README.md` | Add visual navigation, installation, usage, architecture, stack, safety, and recovery documentation. |
| `CHANGELOG.md`, `CONTRIBUTING.md`, `SECURITY.md`, `docs/RELEASE.md` | Document contribution, security, draft, and release contracts. |

## Review order

1. `scripts/validate-package.mjs` and `package.json` — package and release invariants.
2. `.github/workflows/` — CI and tag provenance boundaries.
3. `LICENSE`, `README.md`, and maintainer docs — licensing, usage, and public claims.

## Review workload

- `size:exception` explicitly accepted by the maintainer.
- Review budget: **1,215 changed lines / 400** across 12 files.
- Rationale: the first release foundation combines a 458-line deterministic validator with the package metadata and documentation it validates; the MIT replacement also contributes a large mechanical license-text deletion. Commits preserve coherent review order and rollback boundaries.

## Test plan

- [x] `npm test`
- [x] `npm run pack:check`
- [x] `node --check scripts/validate-package.mjs`
- [x] Workflow YAML parsing and embedded shell/JavaScript syntax checks
- [x] README TOC, badge structure, relative links, and documented claims independently verified
- [x] Final commit scopes and working-tree cleanliness independently verified

## Contributor checklist

- [x] Linked approved issue: #1
- [x] Added exactly one `type:*` label: `type:feature`
- [x] Shellcheck is not applicable because no `.sh` files changed; embedded shell blocks passed `bash -n`
- [x] Skill package structure and metadata passed the project validator
- [x] Documentation was updated with the behavior
- [x] Commits use Conventional Commit format
- [x] No `Co-Authored-By` trailers
